### PR TITLE
Add an "Info" button to the workflow actions page.

### DIFF
--- a/tethysext/workflows/controllers/workflows/workflow_view.py
+++ b/tethysext/workflows/controllers/workflows/workflow_view.py
@@ -50,6 +50,7 @@ class WorkflowView(TethysWorkflowLayout, WorkflowViewMixin):
         """  # noqa: E501
         workflow = self.get_workflow(request, workflow_id, session=session)
         current_step = self.get_step(request, step_id=step_id, session=session)
+        current_step_info_text = current_step.options.get('info_text', None)
         previous_step, next_step = workflow.get_adjacent_steps(current_step)
 
         # Hook for validating the current step
@@ -88,7 +89,6 @@ class WorkflowView(TethysWorkflowLayout, WorkflowViewMixin):
         # Get the current app
         step_url_name = self.get_step_url_name(request, workflow)
 
-
         context.update({
             'workflow': workflow,
             'steps': steps,
@@ -102,6 +102,7 @@ class WorkflowView(TethysWorkflowLayout, WorkflowViewMixin):
             'previous_title': self.previous_title,
             'next_title': self.next_title,
             'finish_title': self.finish_title,
+            'workflow_info_text': current_step_info_text,
         })
 
         # Hook for extending the context

--- a/tethysext/workflows/public/css/workflow_popup.css
+++ b/tethysext/workflows/public/css/workflow_popup.css
@@ -1,0 +1,33 @@
+.popup-text {
+    position: absolute;
+    bottom: 100%; /* Position above the button */
+    margin-bottom: 16px; /* Space between pop-up and button */
+    padding: 20px; /* p-5 */
+    background-color: #1f2937; /* bg-gray-800 */
+    color: white;
+    border-radius: 8px; /* rounded-lg */
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25); /* shadow-2xl */
+    text-align: center;
+    width: 100%;
+    max-width: 320px; /* max-w-xs */
+    transition: opacity 500ms ease, transform 500ms ease; /* transition-all duration-500 */
+    opacity: 0;
+    transform: translateY(8px); /* Start slightly below its final position (to animate upwards) */
+    visibility: hidden; /* Start hidden */
+}
+
+.popup-text.show {
+    opacity: 1;
+    transform: translateY(0); /* translate-y-0 */
+    visibility: visible; /* Make visible when 'show' class is present */
+}
+
+.popup-text p:first-child {
+    font-size: 1.125rem; /* text-lg */
+}
+
+.popup-text p {
+    margin-top: 8px; /* mt-2 */
+    font-size: 0.875rem; /* text-sm */
+    color: #d1d5db; /* text-gray-300 */
+}

--- a/tethysext/workflows/templates/workflows/workflows/components/workflow_actions.html
+++ b/tethysext/workflows/templates/workflows/workflows/components/workflow_actions.html
@@ -13,6 +13,36 @@ Required Context:
 {% endcomment %}
 
 {% block workflow_actions %}
+  {% block workflow_info_button %}
+    {% if workflow_info_text %}
+      <link href="{% static 'workflows/css/workflow_popup.css' %}" rel="stylesheet"/>
+      <button id="popupButton-Info" class="btn btn-info btn-workflow-info" type="button" data-toggle="modal">Info</button>
+
+      <!-- The pop-up text container -->
+      <div id="popupText-Info" class="popup-text">
+        {{ workflow_info_text|safe }}
+      </div>
+      <script>
+        // Get references to the button and the pop-up text element
+        const popupButtonInfo = document.getElementById('popupButton-Info');
+        const popupTextInfo = document.getElementById('popupText-Info');
+
+        // Add a click event listener to the button
+        popupButtonInfo.addEventListener('click', () => {
+            // Toggle the 'show' class to display/hide the text with animation
+            popupTextInfo.classList.toggle('show');
+        });
+
+        // Optional: Hide the pop-up if clicked anywhere outside of it or the button
+        document.addEventListener('click', (event) => {
+            if (!popupButtonInfo.contains(event.target) && !popupTextInfo.contains(event.target) && popupTextInfo.classList.contains('show')) {
+                popupTextInfo.classList.remove('show');
+            }
+        });
+      </script>
+    {% endif %}
+  {% endblock %}
+
   {% block reset_step_button %}
     <button class="btn btn-warning btn-reset" name="reset-submit" type='submit' form="workflow-form">Reset</button>
   {% endblock %}


### PR DESCRIPTION
If a workflow step's options include an entry for extra info, then an Info button will appear at the bottom, and clicking on the button will show a pop-up with the text specified.  The text specified can be in HTML to include hyperlinks, formatting, etc.

Ex:
```step = JobStep(
    name="foo",
    options={
        "info_text": "<p><string>Extra</strong> info to display at the bottom.</p>",
    }
)```