### PR TITLE
Report workflow results fix and enhancements

### DIFF
--- a/tethysext/workflows/controllers/workflows/results_views/report_workflow_results_view.py
+++ b/tethysext/workflows/controllers/workflows/results_views/report_workflow_results_view.py
@@ -64,6 +64,8 @@ class ReportWorkflowResultsView(MapWorkflowView, WorkflowResultsView):
             if isinstance(result, DatasetWorkflowResult):
                 for ds in result.datasets:
                     # Check if the export options is there
+                    if 'show_in_report' in ds and not ds['show_in_report']:
+                        continue
                     data_table = DataTableView(
                         column_names=ds['dataset'].columns,
                         rows=[list(record.values()) for record in ds['dataset'].to_dict(orient='records',

--- a/tethysext/workflows/public/workflows/report_workflow_results_view.js
+++ b/tethysext/workflows/public/workflows/report_workflow_results_view.js
@@ -119,7 +119,7 @@ $(function() {
           margin:       0.3,
           filename:     workflow_name,
           image:        { type: 'jpeg', quality: 1},
-          html2canvas:  { dpi: 192, scale: 4, letterRenderding: true, },
+          html2canvas:  { scale: 4 },
           jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' },
           pagebreak:    { mode: 'avoid-all'}
         };

--- a/tethysext/workflows/results/dataset_workflow_result.py
+++ b/tethysext/workflows/results/dataset_workflow_result.py
@@ -75,7 +75,7 @@ class DatasetWorkflowResult(Result):
         datasets.append(dataset)
         self.datasets = datasets
 
-    def add_pandas_dataframe(self, title, data_frame, show_export_button=False):
+    def add_pandas_dataframe(self, title, data_frame, show_export_button=False, show_in_report=True):
         """
         Adds a pandas.DataFrame to the result.
 
@@ -83,6 +83,7 @@ class DatasetWorkflowResult(Result):
             title(str): Display name.
             data_frame(pandas.DataFrame): The data.
             show_export_button(boolean): Enable data export option.
+            show_in_report(boolean): Enable showing the dataset on a report result.
         """
 
         if not title:
@@ -98,5 +99,6 @@ class DatasetWorkflowResult(Result):
             'title': title,
             'dataset': data_frame,
             'show_export_button': show_export_button,
+            'show_in_report': show_in_report,
         }
         self._add_dataset(d)


### PR DESCRIPTION
Remove invalid options passed to html2pdf, that would result in a blank PDF output when using the "Generate PDF" button.

Allow dataset workflow results to be excluded from report workflow results.  This might be useful in some cases of large datasets that could overload html2pdf, causing it to output a blank PDF (too many pages and html2pdf can result in blank output).  The individual datasets can still be viewed and exported to .csv files from the dataset workflow result tab they are assigned to.  The new option simply allows them to not show up on the report workflow results if desired.